### PR TITLE
Enable simultaneous control of multiple Feedback360 servos

### DIFF
--- a/SUPPORTED.md
+++ b/SUPPORTED.md
@@ -1,4 +1,5 @@
 # Supported List
+
 If you have successfully used this library with an unconfirmed board, please let us know with a Pull Request.
 
 ◯ ... Supported
@@ -11,7 +12,7 @@ If you have successfully used this library with an unconfirmed board, please let
 | Arduino/Genuino Uno | ◯ |
 | Arduino Duemilanove or Diecimila | △ |
 | Arduino Nano | △ |
-| Arduino/Genuino Mega or Mega 2560 | △ |
+| Arduino/Genuino Mega or Mega 2560 | ◯ |
 | Arduino Mega ADK | △ |
 | Arduino Leonardo | △ |
 | Arduino Leonardo ETH | △ |

--- a/examples/MultiMotors/MultiMotors.ino
+++ b/examples/MultiMotors/MultiMotors.ino
@@ -11,19 +11,19 @@ void setup()
 {
     Serial.begin(115200);
 
-    servo1.SetServoControl(9);
-    servo2.SetServoControl(10);
+    servo1.setServoControl(9);
+    servo2.setServoControl(10);
 
-    servo1.SetTarget(500);
-    servo2.SetTarget(5000);
+    servo1.setTarget(300);
+    servo2.setTarget(300);
 }
 
 void loop() 
 {  
-    servo1.Update();
-    servo2.Update();
+    servo1.update();
+    servo2.update();
 
-    Serial.print(servo1.Angle());
+    Serial.print(servo1.getAngle());
     Serial.print(" / ");
-    Serial.println(servo2.Angle());
+    Serial.println(servo2.getAngle());
 }

--- a/examples/MultiMotors/MultiMotors.ino
+++ b/examples/MultiMotors/MultiMotors.ino
@@ -16,6 +16,9 @@ void setup()
 
     servo1.setTarget(300);
     servo2.setTarget(300);
+
+    servo1.setKp(0.5);
+    servo2.setKp(0.5);
 }
 
 void loop() 

--- a/src/FeedBackServo.cpp
+++ b/src/FeedBackServo.cpp
@@ -18,7 +18,7 @@ FeedBackServo* FeedBackServo::instances[MAX_INTERRUPT_NUM] = { nullptr };
 FeedBackServo::FeedBackServo(byte _feedbackPinNumber)
 {
     // feedback pin number validation
-    CheckPin(_feedbackPinNumber);
+    checkPin(_feedbackPinNumber);
     feedbackPinNumber = _feedbackPinNumber;
 
     // convert feedback pin number to interrupt number for use on attachInterrupt function
@@ -38,28 +38,28 @@ FeedBackServo::FeedBackServo(byte _feedbackPinNumber)
     }
 }
 
-void FeedBackServo::SetServoControl(byte servoPinNumber)
+void FeedBackServo::setServoControl(byte servoPinNumber)
 {
     // Servo control pin attach
     Parallax.attach(servoPinNumber);
 }
 
-void FeedBackServo::SetKp(float Kp)
+void FeedBackServo::setKp(float Kp)
 {
     FeedBackServo::Kp_ = Kp;
 }
 
-void FeedBackServo::SetActive(bool isActive)
+void FeedBackServo::setActive(bool isActive)
 {
     isActive_ = isActive;
 }
 
-void FeedBackServo::SetTarget(int target)
+void FeedBackServo::setTarget(int target)
 {
     targetAngle_ = target;
 }
 
-void FeedBackServo::Update(int threshold = 4)
+void FeedBackServo::update(int threshold = 4)
 {
     if (isActive_ == false) return;
 
@@ -77,12 +77,12 @@ void FeedBackServo::Update(int threshold = 4)
     Parallax.writeMicroseconds(1490 - value);
 }
 
-int FeedBackServo::Angle()
+int FeedBackServo::getAngle()
 {
     return angle_;
 }
 
-void FeedBackServo::CheckPin(byte _feedbackPinNumber)
+void FeedBackServo::checkPin(byte _feedbackPinNumber)
 {
 // Check pin number
 #ifdef ARDUINO_AVR_UNO
@@ -109,7 +109,7 @@ void FeedBackServo::CheckPin(byte _feedbackPinNumber)
 #endif
 }
 
-void FeedBackServo::HandleFeedback()
+void FeedBackServo::handleFeedback()
 {
     if (digitalRead(feedbackPinNumber))
     {
@@ -148,9 +148,9 @@ void FeedBackServo::HandleFeedback()
 }
 
 // ISR delegates
-void FeedBackServo::isr0() { if (instances[0]) instances[0]->HandleFeedback(); }
-void FeedBackServo::isr1() { if (instances[1]) instances[1]->HandleFeedback(); }
-void FeedBackServo::isr2() { if (instances[2]) instances[2]->HandleFeedback(); }
-void FeedBackServo::isr3() { if (instances[3]) instances[3]->HandleFeedback(); }
-void FeedBackServo::isr4() { if (instances[4]) instances[4]->HandleFeedback(); }
-void FeedBackServo::isr5() { if (instances[5]) instances[5]->HandleFeedback(); }
+void FeedBackServo::isr0() { if (instances[0]) instances[0]->handleFeedback(); }
+void FeedBackServo::isr1() { if (instances[1]) instances[1]->handleFeedback(); }
+void FeedBackServo::isr2() { if (instances[2]) instances[2]->handleFeedback(); }
+void FeedBackServo::isr3() { if (instances[3]) instances[3]->handleFeedback(); }
+void FeedBackServo::isr4() { if (instances[4]) instances[4]->handleFeedback(); }
+void FeedBackServo::isr5() { if (instances[5]) instances[5]->handleFeedback(); }

--- a/src/FeedBackServo.cpp
+++ b/src/FeedBackServo.cpp
@@ -82,6 +82,11 @@ int FeedBackServo::getAngle()
     return angle_;
 }
 
+int FeedBackServo::Angle()
+{
+    return getAngle();
+}
+
 void FeedBackServo::checkPin(byte _feedbackPinNumber)
 {
 // Check pin number

--- a/src/FeedBackServo.cpp
+++ b/src/FeedBackServo.cpp
@@ -86,6 +86,27 @@ int FeedBackServo::getAngle()
     return angle_;
 }
 
+/*
+ * Legacy blocking rotation function for compatibility.
+ *
+ * This function sets the target angle and actively blocks until the target is reached
+ * within the specified threshold.
+ *
+ * Note:
+ * - Suitable only when controlling a single motor.
+ * - Not recommended in multi-motor systems.
+ * - For non-blocking control, call `setTarget()` and use `update()` in the main loop.
+ */
+void FeedBackServo::rotate(int degree, int threshold)
+{
+    setTarget(degree);
+
+    while (abs(degree - angle_) >= threshold)
+    {
+        update(threshold);
+    }
+}
+
 int FeedBackServo::Angle()
 {
     return getAngle();

--- a/src/FeedBackServo.cpp
+++ b/src/FeedBackServo.cpp
@@ -40,7 +40,7 @@ FeedBackServo::FeedBackServo(byte feedbackPinNumber)
 void FeedBackServo::setServoControl(byte servoPinNumber)
 {
     // Servo control pin attach
-    Parallax_.attach(servoPinNumber);
+    parallax_.attach(servoPinNumber);
 }
 
 void FeedBackServo::setKp(float Kp)
@@ -68,7 +68,7 @@ void FeedBackServo::update(int threshold = 4)
     int errorAngle = targetAngle_ - angle_;
     if (abs(errorAngle) <= threshold)
     {
-        Parallax_.writeMicroseconds(1490);
+        parallax_.writeMicroseconds(1490);
         return;
     }
 
@@ -78,7 +78,7 @@ void FeedBackServo::update(int threshold = 4)
     float offset = (errorAngle > 0) ? 30.0 : -30.0;
     float value = output + offset;
 
-    Parallax_.writeMicroseconds(1490 - value);
+    parallax_.writeMicroseconds(1490 - value);
 }
 
 int FeedBackServo::getAngle()

--- a/src/FeedBackServo.cpp
+++ b/src/FeedBackServo.cpp
@@ -8,10 +8,10 @@
 #include <Servo.h>
 #include "FeedBackServo.h"
 
-const float FeedBackServo::dcMin = 0.029;
-const float FeedBackServo::dcMax = 0.971;
-const int FeedBackServo::q2min = FeedBackServo::unitsFC / 4;
-const int FeedBackServo::q3max = FeedBackServo::q2min * 3;
+const float FeedBackServo::DC_MIN = 0.029;
+const float FeedBackServo::DC_MAX = 0.971;
+const int FeedBackServo::Q2_MIN = FeedBackServo::UNITS_FC / 4;
+const int FeedBackServo::Q3_MAX = FeedBackServo::Q2_MIN * 3;
 
 FeedBackServo* FeedBackServo::instances[MAX_INTERRUPT_NUM] = { nullptr };
 
@@ -125,23 +125,23 @@ void FeedBackServo::handleFeedback()
         if ((tCycle < 1000) || (tCycle > 1200))
             return;
 
-        float dc = (dutyScale * tHigh) / (float)tCycle;
-        float theta = ((dc - dcMin) * unitsFC) / (dcMax - dcMin);
+        float dc = (DUTY_SCALE * tHigh) / (float)tCycle;
+        float theta = ((dc - DC_MIN) * UNITS_FC) / (DC_MAX - DC_MIN);
 
         if (theta < 0.0)
             theta = 0.0;
-        else if (theta > (unitsFC - 1.0))
-            theta = unitsFC - 1.0;
+        else if (theta > (UNITS_FC - 1.0))
+            theta = UNITS_FC - 1.0;
 
-        if ((theta < q2min) && (thetaPre > q3max))
+        if ((theta < Q2_MIN) && (thetaPre > Q3_MAX))
             turns++;
-        else if ((thetaPre < q2min) && (theta > q3max))
+        else if ((thetaPre < Q2_MIN) && (theta > Q3_MAX))
             turns--;
 
         if (turns >= 0)
-            angle_ = (turns * unitsFC) + theta;
+            angle_ = (turns * UNITS_FC) + theta;
         else if (turns < 0)
-            angle_ = ((turns + 1) * unitsFC) - (unitsFC - theta);
+            angle_ = ((turns + 1) * UNITS_FC) - (UNITS_FC - theta);
 
         thetaPre = theta;
     }

--- a/src/FeedBackServo.cpp
+++ b/src/FeedBackServo.cpp
@@ -13,7 +13,7 @@ const float FeedBackServo::dcMax = 0.971;
 const int FeedBackServo::q2min = FeedBackServo::unitsFC / 4;
 const int FeedBackServo::q3max = FeedBackServo::q2min * 3;
 
-FeedBackServo* FeedBackServo::instances[6] = { nullptr };
+FeedBackServo* FeedBackServo::instances[MAX_INTERRUPT_NUM] = { nullptr };
 
 FeedBackServo::FeedBackServo(byte _feedbackPinNumber)
 {
@@ -24,7 +24,7 @@ FeedBackServo::FeedBackServo(byte _feedbackPinNumber)
     // convert feedback pin number to interrupt number for use on attachInterrupt function
     interruptNumber = digitalPinToInterrupt(feedbackPinNumber);
 
-    if (interruptNumber < 6) {
+    if (interruptNumber < MAX_INTERRUPT_NUM) {
         instances[interruptNumber] = this;
         switch (interruptNumber)
         {
@@ -96,6 +96,15 @@ void FeedBackServo::CheckPin(byte _feedbackPinNumber)
         _feedbackPinNumber != 2 &&
         _feedbackPinNumber != 3 &&
         _feedbackPinNumber != 7)
+        exit(1);
+#endif
+#ifdef ARDUINO_AVR_MEGA2560
+    if (_feedbackPinNumber != 2 &&
+        _feedbackPinNumber != 3 &&
+        _feedbackPinNumber != 18 &&
+        _feedbackPinNumber != 19 &&
+        _feedbackPinNumber != 20 &&
+        _feedbackPinNumber != 21)
         exit(1);
 #endif
 }

--- a/src/FeedBackServo.cpp
+++ b/src/FeedBackServo.cpp
@@ -4,10 +4,9 @@
 // Parallax Feedback 360° High Speed Servo is made by Parallax Inc.
 // This library is released under the MIT License.
 
-#include <Arduino.h>
-#include <Servo.h>
 #include "FeedBackServo.h"
 
+// Constants for duty cycle interpretation (based on Parallax spec)
 const float FeedBackServo::DC_MIN = 0.029;
 const float FeedBackServo::DC_MAX = 0.971;
 const int FeedBackServo::Q2_MIN = FeedBackServo::UNITS_FC / 4;
@@ -28,12 +27,12 @@ FeedBackServo::FeedBackServo(byte feedbackPinNumber)
         instances[interruptNumber_] = this;
         switch (interruptNumber_)
         {
-        case 0: attachInterrupt(0, isr0, CHANGE); break;
-        case 1: attachInterrupt(1, isr1, CHANGE); break;
-        case 2: attachInterrupt(2, isr2, CHANGE); break;
-        case 3: attachInterrupt(3, isr3, CHANGE); break;
-        case 4: attachInterrupt(4, isr4, CHANGE); break;
-        case 5: attachInterrupt(5, isr5, CHANGE); break;
+            case 0: attachInterrupt(0, isr0, CHANGE); break;
+            case 1: attachInterrupt(1, isr1, CHANGE); break;
+            case 2: attachInterrupt(2, isr2, CHANGE); break;
+            case 3: attachInterrupt(3, isr3, CHANGE); break;
+            case 4: attachInterrupt(4, isr4, CHANGE); break;
+            case 5: attachInterrupt(5, isr5, CHANGE); break;
         }
     }
 }
@@ -61,6 +60,7 @@ void FeedBackServo::setTarget(int target)
 
 void FeedBackServo::update(int threshold = 4)
 {
+    // Update angle based on the latest PWM feedback
     updateAngleFromPWM();
 
     if (isActive_ == false) return;
@@ -72,6 +72,8 @@ void FeedBackServo::update(int threshold = 4)
         return;
     }
 
+    // NOTE: Using simple P-control.
+    // TODO: PID control may improve stability and response.
     float output = constrain(errorAngle * Kp_, -200.0, 200.0);
     float offset = (errorAngle > 0) ? 30.0 : -30.0;
     float value = output + offset;
@@ -118,6 +120,8 @@ void FeedBackServo::checkPin(byte feedbackPinNumber)
 
 void FeedBackServo::handleFeedback()
 {
+    // Interrupt Service Routine: triggered on pin CHANGE
+    // Records timing only — actual decoding happens in main loop
     if (digitalRead(feedbackPinNumber_))
     {
         rise_ = micros();

--- a/src/FeedBackServo.h
+++ b/src/FeedBackServo.h
@@ -34,6 +34,7 @@ public:
     int getAngle();
 
     // These functions are left for compatibility.
+    void rotate(int degree, int threshold = 4);
     int Angle();
 
 private:

--- a/src/FeedBackServo.h
+++ b/src/FeedBackServo.h
@@ -39,19 +39,20 @@ public:
 private:
     void checkPin(byte pinNumber);
     void handleFeedback();
-    Servo Parallax;
-    byte feedbackPinNumber;
-    byte interruptNumber;
+
+    Servo Parallax_;
+    byte feedbackPinNumber_;
+    byte interruptNumber_;
 
     float Kp_ = 1.0;
     bool isActive_ = true;
     int targetAngle_;
 
     volatile int angle_ = 0;
-    float thetaPre = 0;
-    unsigned int tHigh = 0, tLow = 0;
-    unsigned long rise = 0, fall = 0;
-    int turns = 0;
+    float thetaPre_ = 0;
+    unsigned int tHigh_ = 0, tLow_ = 0;
+    unsigned long rise_ = 0, fall_ = 0;
+    int turns_ = 0;
 
     static const int UNITS_FC = 360; // Full Circle
     static const float DC_MIN;

--- a/src/FeedBackServo.h
+++ b/src/FeedBackServo.h
@@ -26,16 +26,16 @@ class FeedBackServo
 {
 public:
     FeedBackServo(byte feedbackPinNumber);
-    void SetServoControl(byte servoPinNumber = 3);
-    void SetKp(float Kp = 1.0);
-    void SetActive(bool isActive);
-    void SetTarget(int target);
-    void Update(int threshold = 4);
-    int Angle();
+    void setServoControl(byte servoPinNumber = 3);
+    void setKp(float Kp = 1.0);
+    void setActive(bool isActive);
+    void setTarget(int target);
+    void update(int threshold = 4);
+    int getAngle();
 
 private:
-    void CheckPin(byte pinNumber);
-    void HandleFeedback();
+    void checkPin(byte pinNumber);
+    void handleFeedback();
     Servo Parallax;
     byte feedbackPinNumber;
     byte interruptNumber;

--- a/src/FeedBackServo.h
+++ b/src/FeedBackServo.h
@@ -39,6 +39,7 @@ public:
 private:
     void checkPin(byte pinNumber);
     void handleFeedback();
+    void updateAngleFromPWM();
 
     Servo Parallax_;
     byte feedbackPinNumber_;
@@ -53,6 +54,8 @@ private:
     unsigned int tHigh_ = 0, tLow_ = 0;
     unsigned long rise_ = 0, fall_ = 0;
     int turns_ = 0;
+
+    volatile bool feedbackUpdated_ = false;
 
     static const int UNITS_FC = 360; // Full Circle
     static const float DC_MIN;

--- a/src/FeedBackServo.h
+++ b/src/FeedBackServo.h
@@ -53,12 +53,12 @@ private:
     unsigned long rise = 0, fall = 0;
     int turns = 0;
 
-    static const int unitsFC = 360;
-    static const float dcMin;
-    static const float dcMax;
-    static const int dutyScale = 1;
-    static const int q2min;
-    static const int q3max;
+    static const int UNITS_FC = 360; // Full Circle
+    static const float DC_MIN;
+    static const float DC_MAX;
+    static const int DUTY_SCALE = 1;
+    static const int Q2_MIN;
+    static const int Q3_MAX;
 
     static FeedBackServo* instances[MAX_INTERRUPT_NUM];
     static void isr0();

--- a/src/FeedBackServo.h
+++ b/src/FeedBackServo.h
@@ -42,7 +42,7 @@ private:
     void handleFeedback();
     void updateAngleFromPWM();
 
-    Servo Parallax_;
+    Servo parallax_;
     byte feedbackPinNumber_;
     byte interruptNumber_;
 

--- a/src/FeedBackServo.h
+++ b/src/FeedBackServo.h
@@ -4,6 +4,24 @@
 #include <Arduino.h>
 #include <Servo.h>
 
+#ifdef ARDUINO_AVR_UNO
+#define MAX_INTERRUPT_NUM 2
+#endif
+
+#ifdef ARDUINO_AVR_LEONARDO
+#define MAX_INTERRUPT_NUM 5
+#endif
+
+#ifdef ARDUINO_AVR_MEGA2560
+#define MAX_INTERRUPT_NUM 6
+#endif
+
+// If not listed above, leave it at 2.
+// This is just a provisional value; some boards may require a larger value.
+#ifndef MAX_INTERRUPT_NUM
+#define MAX_INTERRUPT_NUM 2
+#endif
+
 class FeedBackServo
 {
 public:
@@ -39,7 +57,7 @@ private:
     static const int q2min;
     static const int q3max;
 
-    static FeedBackServo* instances[6];
+    static FeedBackServo* instances[MAX_INTERRUPT_NUM];
     static void isr0();
     static void isr1();
     static void isr2();

--- a/src/FeedBackServo.h
+++ b/src/FeedBackServo.h
@@ -33,6 +33,9 @@ public:
     void update(int threshold = 4);
     int getAngle();
 
+    // These functions are left for compatibility.
+    int Angle();
+
 private:
     void checkPin(byte pinNumber);
     void handleFeedback();


### PR DESCRIPTION
Fix  #1 :  **Enable simultaneous control of multiple Feedback360 servos**

- Refactored src/FeedBackServo.h and .cpp to support multiple motors
  - Removed static declarations of angle and other variables that should be instance-specific
- Introduced non-blocking P-control using Update() to be called from loop()
- This allows parallel-like control of multiple servos without blocking
- Added example sketch (MultiMotors.ino) demonstrating concurrent control
- Verified parallel control using Arduino UNO and two Feedback360 servos

**複数のFeedback360サーボの同時制御**

- src内の.hおよび.cppファイルに変更を加え、複数モーターの同時制御を可能にしました
  - モーターごとに異なる値を持つ angle などの変数が static だったため、複数制御ができなかったと考えられます
- loop() 内で Update() を呼び出す非ブロッキング型にし、擬似並列制御を可能にしました
- 複数台同時P制御の挙動を確認できる MultiMotors.ino を追加しました
- Arduino UNO + モーター2台で動作確認
- 既存のサンプル（Read.ino と Rotate.ino）は、新しいAPIでは動作しなくなっています